### PR TITLE
remove stale result symlink

### DIFF
--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/yvfsjjsvqplwda3nxv9jqkd53ai7m5am-gosh-0.0.1


### PR DESCRIPTION
You may want to remove those result symlinks, which are artifacts produced by Nix... 

 
_This partially reverts commit 7ccb068279cded1121eacc5a962c14b2064a1859._

_Somewhat related to https://github.com/redcode-labs/GoSH/issues/1._